### PR TITLE
doc: always checkout the whole history

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
 
       - name: Setup Nix
         uses: cachix/install-nix-action@v31
@@ -95,6 +96,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
 
       - name: Setup Nix
         uses: cachix/install-nix-action@v31


### PR DESCRIPTION
Git shallow clone does not work with nix:

```
Updating flake input: blueprint in flake.nix
[command]/nix/var/nix/profiles/default/bin/nix flake update blueprint
error:
       … while fetching the input 'git+file:///home/runner/work/_temp/flake-update-worktrees-svUIh4/update-blueprint'

       error: Failed to retrieve the parent of Git commit 'c9d560db9507bf4ff655e39dcca048318dc26262': object not found - no match for id (f4fef5359d52259eddef39805a01d76f489fc749). This may be due to an incomplete repository history. To resolve this, either enable the shallow parameter in your flake URL (?shallow=1) or add set the shallow parameter to true in builtins.fetchGit, or fetch the complete history for this branch.
```
