### PR TITLE
Fix git authentication in worktrees

### DIFF
--- a/dist/services/githubService.d.ts
+++ b/dist/services/githubService.d.ts
@@ -11,7 +11,8 @@ export declare class GitHubService {
     private context;
     private worktreesDir;
     private gitConfig;
-    constructor(octokit: ReturnType<typeof github.getOctokit>, context: typeof github.context, gitConfig: GitConfig);
+    private githubToken;
+    constructor(octokit: ReturnType<typeof github.getOctokit>, context: typeof github.context, gitConfig: GitConfig, githubToken: string);
     createBranch(branchName: string, baseBranch: string): Promise<string>;
     commitChanges(branchName: string, commitMessage: string, worktreePath: string): Promise<boolean>;
     ensureLabelsExist(labels: string[]): Promise<void>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,7 +140,7 @@ async function run(): Promise<void> {
     const context = github.context;
 
     const flakeService = new FlakeService();
-    githubService = new GitHubService(octokit, context, gitConfig);
+    githubService = new GitHubService(octokit, context, gitConfig, githubToken);
 
     await processFlakeUpdates(flakeService, githubService, excludePatterns, baseBranch, labels, enableAutoMerge, deleteBranchOnMerge);
   } catch (error) {

--- a/tests/integration/processFlakeUpdates.test.ts
+++ b/tests/integration/processFlakeUpdates.test.ts
@@ -102,7 +102,7 @@ describe("processFlakeUpdates Integration Tests", () => {
 
       // Change to temp directory for the test
       process.chdir(tempDir);
-    });
+    }, 15000);
 
     afterEach(() => {
       // Restore original working directory
@@ -150,6 +150,7 @@ describe("processFlakeUpdates Integration Tests", () => {
           repo: { owner: "test", repo: "test-repo" },
         } as any,
         gitConfig,
+        "fake-token-for-testing",
       );
 
       // Process flake updates
@@ -253,7 +254,7 @@ describe("processFlakeUpdates Integration Tests", () => {
 
       // Change to temp directory for the test
       process.chdir(tempDir);
-    });
+    }, 15000);
 
     afterEach(() => {
       // Restore original working directory
@@ -304,6 +305,7 @@ describe("processFlakeUpdates Integration Tests", () => {
           repo: { owner: "test", repo: "test-repo" },
         } as any,
         gitConfig,
+        "fake-token-for-testing",
       );
 
       // Process flake updates


### PR DESCRIPTION
When using git worktrees to isolate flake input updates, the worktrees don't inherit authentication configuration from the main repository. The actions/checkout action configures auth using includeIf directives that are path-specific, so worktrees created in temp directories lack credentials for pushing to GitHub.

This caused push failures with "fatal: could not read Username for
'https://github.com': No such device or address" (exit code 128).

The fix configures http.extraheader with GitHub token authentication in each worktree after creation, matching how actions/checkout sets up auth. Also increased beforeEach timeout in tests from 5s to 15s to accommodate nix flake lock operations.