### PR TITLE
add auto-merge-method option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ jobs:
           # pr-labels: 'dependencies,automated'
           # Optional: enable auto-merge (default: false)
           # auto-merge: 'true'
+          # Optional: choose merge method when auto-merge is enabled (default: MERGE)
+          # auto-merge-method: 'SQUASH'
 ```
 
 ### Using with GitHub App Token (Recommended)
@@ -138,6 +140,8 @@ jobs:
           # pr-labels: 'dependencies,automated'
           # Optional: enable auto-merge (default: false)
           # auto-merge: 'true'
+          # Optional: choose merge method when auto-merge is enabled (default: MERGE)
+          # auto-merge-method: 'SQUASH'
 ```
 
 **That's it!** Your workflow is now set up. It will:
@@ -183,6 +187,7 @@ The GitHub App needs the following repository permissions:
 | `exclude-patterns` | Comma-separated list of glob patterns to exclude flake.nix files or specific inputs using `pattern#inputname` syntax | No | `''` |
 | `pr-labels` | Comma-separated list of labels to add to created pull requests (labels will be created if they don't exist) | No | `'dependencies'` |
 | `auto-merge` | Enable auto-merge for created pull requests (requires auto-merge to be enabled in repository settings) | No | `'false'` |
+| `auto-merge-method` | Merge strategy used when auto-merge is enabled (`MERGE`, `SQUASH`, or `REBASE`) | No | `'MERGE'` |
 | `delete-branch` | Delete branch after pull request is merged | No | `'true'` |
 | `signoff` | Add sign-off to commits | No | `'true'` |
 | `git-author-name` | Git author name for commits | No | `'github-actions[bot]'` |

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: 'Enable auto-merge for created pull requests'
     required: false
     default: 'false'
+  auto-merge-method:
+    description: 'Merge method to use when auto-merge is enabled (MERGE, SQUASH, REBASE)'
+    required: false
+    default: 'MERGE'
   git-author-name:
     description: 'Git author name for commits'
     required: false

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,3 +1,4 @@
 import { FlakeService } from './services/flakeService';
 import { GitHubService } from './services/githubService';
-export declare function processFlakeUpdates(flakeService: FlakeService, githubService: GitHubService, excludePatterns: string, baseBranch: string, labels: string[], enableAutoMerge: boolean, deleteBranchOnMerge: boolean): Promise<void>;
+export type AutoMergeMethod = "MERGE" | "SQUASH" | "REBASE";
+export declare function processFlakeUpdates(flakeService: FlakeService, githubService: GitHubService, excludePatterns: string, baseBranch: string, labels: string[], enableAutoMerge: boolean, autoMergeMethod: AutoMergeMethod, deleteBranchOnMerge: boolean): Promise<void>;

--- a/dist/services/githubService.d.ts
+++ b/dist/services/githubService.d.ts
@@ -15,8 +15,8 @@ export declare class GitHubService {
     createBranch(branchName: string, baseBranch: string): Promise<string>;
     commitChanges(branchName: string, commitMessage: string, worktreePath: string): Promise<boolean>;
     ensureLabelsExist(labels: string[]): Promise<void>;
-    enableAutoMerge(pullRequestNodeId: string, pullRequestNumber: number, headSha: string, mergeMethod?: "MERGE" | "SQUASH" | "REBASE"): Promise<boolean>;
-    createPullRequest(branchName: string, baseBranch: string, title: string, body: string, labels?: string[], enableAutoMerge?: boolean, deleteBranchOnMerge?: boolean): Promise<void>;
+    enableAutoMerge(pullRequestNodeId: string, pullRequestNumber: number, headSha: string, mergeMethod: "MERGE" | "SQUASH" | "REBASE"): Promise<boolean>;
+    createPullRequest(branchName: string, baseBranch: string, title: string, body: string, labels?: string[], enableAutoMerge?: boolean, autoMergeMethod?: "MERGE" | "SQUASH" | "REBASE", deleteBranchOnMerge?: boolean): Promise<void>;
     cleanupWorktree(worktreePath: string): Promise<void>;
     cleanupAllWorktrees(): Promise<void>;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "update-flake-inputs-action",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "update-flake-inputs-action",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",
@@ -125,6 +125,7 @@
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1567,6 +1568,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -1958,6 +1960,7 @@
       "integrity": "sha512-FuYgkHwZLuPbZjQHzJXrtXreJdFMKl16BFYyRrLxDhWr6Qr7Kbcu2s1Yhu8tsiMXw1S0W1pjfFfYEt+R604s+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.36.0",
         "@typescript-eslint/types": "8.36.0",
@@ -2448,6 +2451,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2707,6 +2711,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -3136,6 +3141,7 @@
       "integrity": "sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4051,6 +4057,7 @@
       "integrity": "sha512-9QE0RS4WwTj/TtTC4h/eFVmFAhGNVerSB9XpJh8sqaXlP73ILcPcZ7JWjjEtJJe2m8QyBLKKfPQuK+3F+Xij/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.0.4",
         "@jest/types": "30.0.1",
@@ -6065,6 +6072,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/services/githubService.ts
+++ b/src/services/githubService.ts
@@ -200,7 +200,7 @@ export class GitHubService {
     pullRequestNodeId: string,
     pullRequestNumber: number,
     headSha: string,
-    mergeMethod: "MERGE" | "SQUASH" | "REBASE" = "MERGE",
+    mergeMethod: "MERGE" | "SQUASH" | "REBASE",
   ): Promise<boolean> {
     try {
       // First check if auto-merge is allowed on the repository
@@ -285,6 +285,7 @@ export class GitHubService {
     body: string,
     labels: string[] = [],
     enableAutoMerge = false,
+    autoMergeMethod?: "MERGE" | "SQUASH" | "REBASE",
     deleteBranchOnMerge = true,
   ): Promise<void> {
     try {
@@ -336,7 +337,17 @@ export class GitHubService {
 
       // Enable auto-merge if requested
       if (enableAutoMerge) {
-        await this.enableAutoMerge(pr.node_id, pr.number, pr.head.sha);
+        if (!autoMergeMethod) {
+          throw new Error(
+            "Auto-merge method must be provided when auto-merge is enabled.",
+          );
+        }
+        await this.enableAutoMerge(
+          pr.node_id,
+          pr.number,
+          pr.head.sha,
+          autoMergeMethod,
+        );
       }
 
       // Set delete branch on merge if needed

--- a/tests/integration/processFlakeUpdates.test.ts
+++ b/tests/integration/processFlakeUpdates.test.ts
@@ -47,6 +47,8 @@ class TestGitHubService extends GitHubService {
     body: string,
     labels: string[] = [],
     enableAutoMerge = false,
+    autoMergeMethod?: "MERGE" | "SQUASH" | "REBASE",
+    deleteBranchOnMerge = true,
   ): Promise<void> {
     // Record the attempt but don't actually create a PR
     this.prCreationAttempts.push({ branchName, baseBranch, title, body });
@@ -160,6 +162,7 @@ describe("processFlakeUpdates Integration Tests", () => {
         "main",
         [],
         false,
+        "MERGE",
         true,
       );
 
@@ -314,6 +317,7 @@ describe("processFlakeUpdates Integration Tests", () => {
         "main",
         [],
         false,
+        "MERGE",
         true,
       );
 


### PR DESCRIPTION
Hi! The auto merge method was hardcoded to merge commits, so exposed the method as an option.

Currently you have to set `auto-merge: true` and `auto-merge-method: squash`, but if you prefer I can change it so you just set `auto-merge: squash`.