### PR TITLE
fix: clear existing Authorization header before setting new one

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -30389,12 +30389,19 @@ class GitHubService {
                 branchName,
             ]);
             // Configure git authentication in the worktree
+            // First unset any existing extraheader to avoid duplicate Authorization headers
+            await exec.exec("git", [
+                "config",
+                "--local",
+                "--unset-all",
+                `http.https://github.com/.extraheader`,
+            ], { cwd: worktreePath, ignoreReturnCode: true });
             const basicAuth = Buffer.from(`x-access-token:${this.githubToken}`).toString("base64");
             await exec.exec("git", [
                 "config",
                 "--local",
                 `http.https://github.com/.extraheader`,
-                `AUTHORIZATION: basic ${basicAuth}`,
+                `Authorization: basic ${basicAuth}`,
             ], { cwd: worktreePath });
             core.info(`Created worktree for branch ${branchName} at ${worktreePath}`);
             return worktreePath;

--- a/src/services/githubService.ts
+++ b/src/services/githubService.ts
@@ -99,6 +99,18 @@ export class GitHubService {
       ]);
 
       // Configure git authentication in the worktree
+      // First unset any existing extraheader to avoid duplicate Authorization headers
+      await exec.exec(
+        "git",
+        [
+          "config",
+          "--local",
+          "--unset-all",
+          `http.https://github.com/.extraheader`,
+        ],
+        { cwd: worktreePath, ignoreReturnCode: true },
+      );
+
       const basicAuth = Buffer.from(
         `x-access-token:${this.githubToken}`,
       ).toString("base64");
@@ -108,7 +120,7 @@ export class GitHubService {
           "config",
           "--local",
           `http.https://github.com/.extraheader`,
-          `AUTHORIZATION: basic ${basicAuth}`,
+          `Authorization: basic ${basicAuth}`,
         ],
         { cwd: worktreePath },
       );


### PR DESCRIPTION
GitHub Actions' checkout action sets http.https://github.com/.extraheader with an Authorization header. When our code added another one (with different casing), git sent both headers causing a "Duplicate header: Authorization" error from GitHub's servers.

Fix by unsetting any existing extraheader values before configuring authentication in worktrees.