### PR TITLE
fix: rely on checkout action for git authentication

### DIFF
--- a/dist/services/githubService.d.ts
+++ b/dist/services/githubService.d.ts
@@ -11,10 +11,7 @@ export declare class GitHubService {
     private context;
     private worktreesDir;
     private gitConfig;
-    private githubToken;
-    private authConfigured;
-    constructor(octokit: ReturnType<typeof github.getOctokit>, context: typeof github.context, gitConfig: GitConfig, githubToken: string);
-    private configureGitAuth;
+    constructor(octokit: ReturnType<typeof github.getOctokit>, context: typeof github.context, gitConfig: GitConfig);
     createBranch(branchName: string, baseBranch: string): Promise<string>;
     commitChanges(branchName: string, commitMessage: string, worktreePath: string): Promise<boolean>;
     ensureLabelsExist(labels: string[]): Promise<void>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,7 +140,7 @@ async function run(): Promise<void> {
     const context = github.context;
 
     const flakeService = new FlakeService();
-    githubService = new GitHubService(octokit, context, gitConfig, githubToken);
+    githubService = new GitHubService(octokit, context, gitConfig);
 
     await processFlakeUpdates(flakeService, githubService, excludePatterns, baseBranch, labels, enableAutoMerge, deleteBranchOnMerge);
   } catch (error) {

--- a/tests/integration/processFlakeUpdates.test.ts
+++ b/tests/integration/processFlakeUpdates.test.ts
@@ -150,7 +150,6 @@ describe("processFlakeUpdates Integration Tests", () => {
           repo: { owner: "test", repo: "test-repo" },
         } as any,
         gitConfig,
-        "fake-token-for-testing",
       );
 
       // Process flake updates
@@ -305,7 +304,6 @@ describe("processFlakeUpdates Integration Tests", () => {
           repo: { owner: "test", repo: "test-repo" },
         } as any,
         gitConfig,
-        "fake-token-for-testing",
       );
 
       // Process flake updates


### PR DESCRIPTION
Remove our own git auth configuration since actions/checkout already sets up authentication via includeIf directives. Setting our own extraheader caused duplicate Authorization headers because both configs were applied when pushing from worktrees.

The fix is simpler: just don't configure auth ourselves and rely on checkout having been called with the correct token.